### PR TITLE
Some fixes to work with the current NixOS again

### DIFF
--- a/nix-docker/modules/config/environment.nix
+++ b/nix-docker/modules/config/environment.nix
@@ -47,7 +47,7 @@ in {
 
     docker.buildScripts."0-etc" = ''
         echo "setting up /etc..."
-        ${pkgs.perl}/bin/perl ${<nixpkgs/nixos/modules/system/etc/setup-etc.pl>} ${etc}/etc
+        ${pkgs.perl}/bin/perl -I${pkgs.perlPackages.FileSlurp}/lib/perl5/site_perl ${<nixpkgs/nixos/modules/system/etc/setup-etc.pl>} ${etc}/etc
       '';
   };
 }

--- a/nix-docker/modules/servers/openssh.nix
+++ b/nix-docker/modules/servers/openssh.nix
@@ -262,7 +262,7 @@ in
 
         preStart =
           ''
-            mkdir -m 0755 -p /etc/ssh
+            ${pkgs.coreutils}/bin/mkdir -m 0755 -p /etc/ssh
 
             ${flip concatMapStrings cfg.hostKeys (k: ''
               if ! [ -f "${k.path}" ]; then


### PR DESCRIPTION
The File::Slurp dependency was added in https://github.com/NixOS/nixpkgs/commit/7c480ad89695c1309cc2ed5d07c166722476cd8c

I'm not sure I understand why the path to mkdir needed to be explicitly spelled out in openssh.nix, but it was failing without it.

Tested on NixOS 14.11pre54200.0b1d16c

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zefhemel/nix-docker/12)
<!-- Reviewable:end -->
